### PR TITLE
Use `display: contents` for tooltip targets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -87,7 +87,7 @@ function createMainWindow() {
 		darkTheme: isDarkMode, // GTK+3
 		webPreferences: {
 			webviewTag: false, // Disabled for security reasons since we don't use it
-			blinkFeatures: 'CSSBackdropFilter',
+			blinkFeatures: 'CSSBackdropFilter, CSSDisplayContents',
 		},
 	});
 

--- a/app/renderer/components/Tooltip.js
+++ b/app/renderer/components/Tooltip.js
@@ -98,6 +98,7 @@ class Tooltip extends React.PureComponent {
 					{({ref}) => (
 						<div
 							ref={ref}
+							className="Tooltip__target"
 							onMouseEnter={this.handleMouseEnter}
 							onMouseLeave={this.handleMouseLeave}
 						>

--- a/app/renderer/components/Tooltip.scss
+++ b/app/renderer/components/Tooltip.scss
@@ -7,7 +7,7 @@
 	transition-timing-function: ease-out;
 
 	&__target {
-		overflow: hidden;
+		display: contents;
 	}
 
 	&__container {


### PR DESCRIPTION
Until we upgrade to Electron 3, we can enable `display: contents` using this flag.

Fixes #374.