### PR TITLE
Revert using `display: contents` on tooltip targets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -87,7 +87,7 @@ function createMainWindow() {
 		darkTheme: isDarkMode, // GTK+3
 		webPreferences: {
 			webviewTag: false, // Disabled for security reasons since we don't use it
-			blinkFeatures: 'CSSBackdropFilter, CSSDisplayContents',
+			blinkFeatures: 'CSSBackdropFilter',
 		},
 	});
 

--- a/app/renderer/components/Tooltip.js
+++ b/app/renderer/components/Tooltip.js
@@ -98,7 +98,6 @@ class Tooltip extends React.PureComponent {
 					{({ref}) => (
 						<div
 							ref={ref}
-							className="Tooltip__target"
 							onMouseEnter={this.handleMouseEnter}
 							onMouseLeave={this.handleMouseLeave}
 						>

--- a/app/renderer/components/Tooltip.scss
+++ b/app/renderer/components/Tooltip.scss
@@ -6,10 +6,6 @@
 	transition-property: opacity, transform;
 	transition-timing-function: ease-out;
 
-	&__target {
-		display: contents;
-	}
-
 	&__container {
 		z-index: 1100;
 	}


### PR DESCRIPTION
Since it doesn't inherit the childs position, but is removed from the layout altogether, the `ref` will use that position and always be shown in the top corner.

<img width="146" alt="screen shot 2018-06-25 at 19 44 26" src="https://user-images.githubusercontent.com/709159/41866409-5239390a-78b0-11e8-874b-a8e8f4a56305.png">
