### PR TITLE
Add dashboard intro

### DIFF
--- a/app/locales/en-US/dashboard.json
+++ b/app/locales/en-US/dashboard.json
@@ -1,7 +1,7 @@
 {
 	"intro": {
 		"title": "✨ Thanks for Helping Us Test HyperDEX!",
-		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><1>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</1><2>If you just want to test HyperDEX, try trading between the test currencies <1>BEER</1> and <2>PIZZA</2> instead. You can get free <3>BEER</3> at the <4><1>BEER</1> faucet</4>.</2><3>HyperDEX is Open Source software provided \"as is\", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</3><4>By using HyperDEX you are agreeing to the terms of the <1>MIT License</1>.</4>"
+		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><2>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</2><3>If you just want to test HyperDEX, try trading between the test currencies <4>BEER</4> and <5>PIZZA</5> instead. You can get free <6>BEER</6> at the <7><8>BEER</8> faucet</7>.</3><9>HyperDEX is Open Source software provided \"as is\", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</9><10>By using HyperDEX you are agreeing to the terms of the <11>MIT License</11>.</10>"
 	},
 	"activity": {
 		"noActivity": "No activity yet",

--- a/app/locales/en-US/dashboard.json
+++ b/app/locales/en-US/dashboard.json
@@ -1,7 +1,7 @@
 {
 	"intro": {
 		"title": "✨ Thanks for Helping Us Test HyperDEX!",
-		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><2>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</2><3>If you just want to test HyperDEX, try trading between the test currencies <4>BEER</4> and <5>PIZZA</5> instead. You can get free <6>BEER</6> at the <7><8>BEER</8> faucet</7>.</3><9>HyperDEX is Open Source software provided \"as is\", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</9><10>By using HyperDEX you are agreeing to the terms of the <11>MIT License</11>.</10>"
+		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><1>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</1><2>If you just want to test HyperDEX, try trading between the test currencies <1>BEER</1> and <3>PIZZA</3> instead. You can get free <5>BEER</5> at the <7><0>BEER</0> faucet</7>.</2><3>HyperDEX is Open Source software provided &qoute;as is&qoute;, without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</3><4>By using HyperDEX you are agreeing to the terms of the <1>MIT License</1>.</4>"
 	},
 	"activity": {
 		"noActivity": "No activity yet",

--- a/app/locales/en-US/dashboard.json
+++ b/app/locales/en-US/dashboard.json
@@ -1,4 +1,8 @@
 {
+	"intro": {
+		"title": "✨ Thanks for Helping us Test HyperDEX!",
+		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><1>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</1><2>If you just want to test HyperDEX, try trading between the test currencies <1>BEER</1> and <2>PIZZA</2> instead. You can get free <3>BEER</3> at the <4><1>BEER</1> faucet</4>.</2><3>HyperDEX is Open Source software provided \"as is\", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</3><4>By using HyperDEX you are agreeing to the terms of the <1>MIT License</1>.</4>"
+	},
 	"activity": {
 		"noActivity": "No activity yet",
 		"recentActivity": "Recent Activity",

--- a/app/locales/en-US/dashboard.json
+++ b/app/locales/en-US/dashboard.json
@@ -1,6 +1,6 @@
 {
 	"intro": {
-		"title": "✨ Thanks for Helping us Test HyperDEX!",
+		"title": "✨ Thanks for Helping Us Test HyperDEX!",
 		"description": "<0>Please keep in mind <1>this project is still in Alpha</1>.</0><1>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</1><2>If you just want to test HyperDEX, try trading between the test currencies <1>BEER</1> and <2>PIZZA</2> instead. You can get free <3>BEER</3> at the <4><1>BEER</1> faucet</4>.</2><3>HyperDEX is Open Source software provided \"as is\", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</3><4>By using HyperDEX you are agreeing to the terms of the <1>MIT License</1>.</4>"
 	},
 	"activity": {

--- a/app/renderer/views/Dashboard/Intro.js
+++ b/app/renderer/views/Dashboard/Intro.js
@@ -1,0 +1,43 @@
+import {remote} from 'electron';
+import React from 'react';
+import {Trans} from 'react-i18next';
+import Modal from 'components/Modal';
+import ExternalLink from 'components/ExternalLink';
+import {instance, translate} from '../../translate';
+
+const config = remote.require('./config');
+const t = translate('dashboard');
+
+class Intro extends React.Component {
+	state = {
+		shouldOpen: true || !config.get('hasShownDashboardIntro'),
+	}
+
+	closedHandler = () => {
+		config.set('hasShownDashboardIntro', true);
+		this.setState({shouldOpen: false});
+	};
+
+	render() {
+		return (
+			<div>
+				<Modal
+					title={t('intro.title')}
+					open={this.state.shouldOpen}
+					didClose={this.closedHandler}
+					width="500px"
+				>
+					<Trans i18n={instance} i18nKey="intro.description" t={t}>
+						<p>Please keep in mind <strong>this project is still in Alpha</strong>.</p>
+						<p>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</p>
+						<p>If you just want to test HyperDEX, try trading between the test currencies <strong>BEER</strong> and <strong>PIZZA</strong> instead. You can get free <strong>BEER</strong> at the <ExternalLink url="https://www.atomicexplorer.com/#/faucet"><strong>BEER</strong> faucet</ExternalLink>.</p>
+						<p>HyperDEX is Open Source software provided "as is", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</p>
+						<p>By using HyperDEX you are agreeing to the terms of the <ExternalLink url="https://github.com/hyperdexapp/hyperdex/blob/master/LICENSE">MIT License</ExternalLink>.</p>
+					</Trans>
+				</Modal>
+			</div>
+		);
+	}
+}
+
+export default Intro;

--- a/app/renderer/views/Dashboard/Intro.js
+++ b/app/renderer/views/Dashboard/Intro.js
@@ -10,7 +10,7 @@ const t = translate('dashboard');
 
 class Intro extends React.Component {
 	state = {
-		shouldOpen: true || !config.get('hasShownDashboardIntro'),
+		shouldOpen: !config.get('hasShownDashboardIntro'),
 	}
 
 	closedHandler = () => {

--- a/app/renderer/views/Dashboard/Intro.js
+++ b/app/renderer/views/Dashboard/Intro.js
@@ -31,7 +31,7 @@ class Intro extends React.Component {
 						<p>Please keep in mind <strong>this project is still in Alpha</strong>.</p>
 						<p>Although loss of funds is unlikely, you should only trade with real currency if you can take that risk.</p>
 						<p>If you just want to test HyperDEX, try trading between the test currencies <strong>BEER</strong> and <strong>PIZZA</strong> instead. You can get free <strong>BEER</strong> at the <ExternalLink url="https://www.atomicexplorer.com/#/faucet"><strong>BEER</strong> faucet</ExternalLink>.</p>
-						<p>HyperDEX is Open Source software provided "as is", without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</p>
+						<p>HyperDEX is Open Source software provided &qoute;as is&qoute;, without warranty of any kind. The authors or copyright holders are not liable for any damages caused as a result of using this software.</p>
 						<p>By using HyperDEX you are agreeing to the terms of the <ExternalLink url="https://github.com/hyperdexapp/hyperdex/blob/master/LICENSE">MIT License</ExternalLink>.</p>
 					</Trans>
 				</Modal>

--- a/app/renderer/views/Dashboard/index.js
+++ b/app/renderer/views/Dashboard/index.js
@@ -3,6 +3,7 @@ import {Subscribe} from 'unstated';
 import dashboardContainer from 'containers/Dashboard';
 import exchangeContainer from 'containers/Exchange';
 import TabView from 'views/TabView';
+import Intro from './Intro';
 import List from './List';
 import Chart from './Chart';
 import Activity from './Activity';
@@ -19,6 +20,7 @@ const Dashboard = () => {
 				if (state.activeView === 'Portfolio') {
 					return (
 						<TabView className="Dashboard Dashboard--Portfolio">
+							<Intro/>
 							<List/>
 							<Chart/>
 							<Activity/>


### PR DESCRIPTION
Hopefully this will notify all users of the risks and make them aware of the maturity of the software.

MIT license should cover us for any legal disputes but @pondsea wanted me to explicitly bring it up here too. I give a breif summary about no warranty/liability and state that "By using HyperDEX you are agreeing to the terms of the MIT License".

I think that should be more than enough.

![screen shot 2018-06-29 at 3 10 01 pm](https://user-images.githubusercontent.com/2123375/42081493-c56c0342-7baf-11e8-9ec5-96782de099a8.png)

The screenshot was taken with localisation disabled. Using the localisation files the text gets a bit garbled. I tried to copy the `<n>` pattern I'd seen in other localisation files but it doesn't look like I got it right. Is this a standardised format? Is there an automatic conversion tool we can use instead of manually creating the `<n>` tags.

Also, suggestions for text modifications welcome.