### PR TITLE
Create `signchecksum` script

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -15,3 +15,11 @@ $ yarn release
 ```
 
 Then edit the automatically created GitHub Releases draft and publish.
+
+Once the release is published you can automatically generate a signed checksum file with:
+
+```
+$ ./signedchecksum
+```
+
+It will create a file called `SHASUMS256.txt.asc`, you should manually upload this file to the GitHub release.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -22,4 +22,4 @@ Once the release is published you can automatically generate a signed checksum f
 $ ./signedchecksum
 ```
 
-It will create a file called `SHASUMS256.txt.asc`, you should manually upload this file to the GitHub release.
+It will create a file called `SHASUMS256.txt.asc` that you need to upload to the GitHub release manually.

--- a/signedchecksum
+++ b/signedchecksum
@@ -11,6 +11,6 @@ curl https://api.github.com/repos/hyperdexapp/hyperdex/releases/latest | jq '.as
 echo "Calculating checksums and signing the result..."
 
 export GPG_TTY=$(tty)
-shasum -a 256 * | gpg --clearsign > "$run_dir/SHASUMS256.txt.asc"
+shasum --algorithmn 256 * | gpg --clearsign > "$run_dir/SHASUMS256.txt.asc"
 
 echo "Created SHASUM256.txt.asc"

--- a/signedchecksum
+++ b/signedchecksum
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+run_dir=$(pwd)
+cd $(mktemp -d)
+
+echo "Downloading build artefacts to temporary directory:"
+pwd
+
+curl https://api.github.com/repos/hyperdexapp/hyperdex/releases/latest | jq '.assets[].browser_download_url' | xargs wget
+
+echo "Calculating checksums and signing the result..."
+
+export GPG_TTY=$(tty)
+shasum -a 256 * | gpg --clearsign > "$run_dir/SHASUMS256.txt.asc"
+
+echo "Created SHASUM256.txt.asc"
+

--- a/signedchecksum
+++ b/signedchecksum
@@ -14,4 +14,3 @@ export GPG_TTY=$(tty)
 shasum -a 256 * | gpg --clearsign > "$run_dir/SHASUMS256.txt.asc"
 
 echo "Created SHASUM256.txt.asc"
-

--- a/signedchecksum
+++ b/signedchecksum
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 run_dir=$(pwd)
 cd $(mktemp -d)


### PR DESCRIPTION
Resolves #393 

So ideally we'd have checksumming and signing automated by our build system. However there's currently no simple way to do this without forking our build tools and adding this functionality or significantly changing our build setup.

For now I've just created a script that will pull down all build artefacts from the  latest GitHub release and create checksums and sign them. We can then manually upload the checksum file. I'm using my personal PGP key to sign the checksums. I think for now it's fine for any core developer to use this script to sign the checksums as their identity can be verified on https://keybase.io.

Going forward it would be great if we can work with `electron-builder` to integrate this functionality into their tooling. It must be a pretty common requirement. We should probably also create a dedicated HyperDEX release PGP key for signing.

**Not sure if this script really belongs in the code base but it might be good to have here until we have an automated solution in case we need to do a release when I'm not around.**